### PR TITLE
docs: fix references to menubar

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## seeking contributors!
 
-this is a FOSS effort and will never be commercialized (no tracking, will not be a paid app (but the chat apps within might), etc). please check out the feature requests (https://github.com/smol-ai/menubar/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc) if you'd like to help! in particular, we'd like:
+this is a FOSS effort and will never be commercialized (no tracking, will not be a paid app (but the chat apps within might), etc). please check out the feature requests (https://github.com/smol-ai/GodMode/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc) if you'd like to help! in particular, we'd like:
 
 - **a PR to make the 3 panels customizable to different URLs and input targets!**
 - a "Windows maintainer" to handle Windows user needs and beta test every release to make sure we didn't break something for them
@@ -14,8 +14,8 @@ To install and run from source, follow these steps:
 1. Clone the repository and navigate to the project folder:
 
    ```bash
-   git clone https://github.com/smol-ai/menubar.git
-   cd menubar
+   git clone https://github.com/smol-ai/GodMode.git
+   cd GodMode
    ```
 
 2. Install dependencies:
@@ -34,7 +34,7 @@ To install and run from source, follow these steps:
 
 ## debugging
 
-I have the menubar devtools up all the time while in development. You can disable them by commenting this line.
+I have the devtools up all the time while in development. You can disable them by commenting this line.
 
 ```js
 window.webContents.openDevTools();

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a dedicated chat browser that only does one thing: help you quickly access **the full webapps** of ChatGPT, Claude 2, Perplexity, Bing and more **with a single keyboard shortcut (Cmd+Shift+G)**.
 
-![image](https://github.com/smol-ai/menubar/assets/6764957/90f4bab4-e406-4507-b37e-8c8d80d18f15)
+![image](https://github.com/smol-ai/GodMode/assets/6764957/90f4bab4-e406-4507-b37e-8c8d80d18f15)
 
 ([click for video](https://twitter.com/swyx/status/1692988634364871032))
 
@@ -48,16 +48,16 @@ Yes and no:
 | Local/GGML Models (via [OobaBooga](https://github.com/oobabooga/text-generation-webui)) | Requires Local Setup, see oobabooga docs                                                                                                                                 |
 | Phind                                                                                   | Developer focused chat (temporarily disabled)                                                                                                                            |
 | [OpenRouter](https://openrouter.ai)                                                     | Access GPT4, Claude, PaLM, and open source models                                                                                                                        |
-| OpenAssistant                                                                           | Coming Soon — [Submit a PR](https://github.com/smol-ai/menubar/issues/37)!                                                                                               |
+| OpenAssistant                                                                           | Coming Soon — [Submit a PR](https://github.com/smol-ai/GodMode/issues/37)!                                                                                               |
 | Claude 1                                                                                | Requires Beta Access                                                                                                                                                     |
-| ... What Else?                                                                          | [Submit a New Issue](https://github.com/smol-ai/menubar/issues)!                                                                                                         |
+| ... What Else?                                                                          | [Submit a New Issue](https://github.com/smol-ai/GodMode/issues)!                                                                                                         |
 
 ## Features and Usage
 
 - **Keyboard Shortcuts**:
 
   - Use `Cmd+Shift+G` for quick open and `Cmd+Enter` to submit.
-  - Customize these shortcuts (thanks [@davej](https://github.com/smol-ai/menubar/pull/85)!):
+  - Customize these shortcuts (thanks [@davej](https://github.com/smol-ai/GodMode/pull/85)!):
     - Quick Open
       - ![image](https://github.com/davej/smol-ai-menubar/assets/6764957/3a6d0a16-7f54-43e5-9060-ec7b2486d32d)
     - Submit can be toggled to use `Enter` (faster for quick chat replies) vs `Cmd+Enter` (easier to enter multiline prompts)
@@ -81,7 +81,7 @@ Yes and no:
 
   - Initial support for [oobabooga/text-generation-webui](https://github.com/oobabooga/text-generation-webui) has been added.
   - Users need to follow the process outlined in the text-generation-webui repository, including downloading models (e.g. [LLaMa-13B-GGML](https://huggingface.co/TheBloke/LLaMa-13B-GGML/blob/main/llama-13b.ggmlv3.q4_0.bin)).
-  - Run the model on `http://127.0.0.1:7860/` before running it inside of the smol menubar.
+  - Run the model on `http://127.0.0.1:7860/` before running it inside of the smol GodMode browser.
   - The UI only supports one kind of prompt template. Contributions are welcome to make the templating customizable (see the Oobabooga.js provider).
 
 - **Starting New Conversations**:
@@ -123,7 +123,7 @@ If you want to build from source, you will need to clone the repo and open the p
 
    ```bash
    git clone https://github.com/smol-ai/GodMode.git
-   cd menubar
+   cd GodMode
    npm install
    # On Windows, you may also need Squirrel - these are old instructions, we would love a Windows volunteer to verify
    # npm install electron-squirrel-startup

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/smol-ai/menubar"
+		"url": "https://github.com/smol-ai/GodMode"
 	},
 	"devDependencies": {
 		"@electron/notarize": "^1.2.3",
@@ -186,7 +186,7 @@
 		"publish": {
 			"provider": "github",
 			"owner": "smol-ai",
-			"repo": "menubar"
+			"repo": "GodMode"
 		}
 	},
 	"devEngines": {

--- a/src/renderer/browserPane.tsx
+++ b/src/renderer/browserPane.tsx
@@ -333,7 +333,7 @@ export function BrowserPane({
 										<Menu.Item>
 											{({ active }) => (
 												<a
-													href="https://github.com/smol-ai/menubar/issues/new"
+													href="https://github.com/smol-ai/GodMode/issues/new"
 													target="_blank"
 													// className="flex items-center justify-center px-4 py-2 text-white bg-teal-700 rounded hover:bg-teal-500"
 													className={classNames(


### PR DESCRIPTION
Not sure if this really matters given GH's redirecting, so happy to pull back on this. I think keeping the cd GodMode instruction in the README is valuable though.

I didn't change any of the apple signing instructions, as I haven't tested them and didn't want to unintentionally break the workflow.