### PR TITLE
linux/win support

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,9 +144,11 @@
 				"target": "default",
 				"arch": [
 					"arm64",
+					"'universal",
 					"x64"
 				]
 			},
+			"category": "public.app-category.developer-tools",
 			"type": "distribution",
 			"hardenedRuntime": true,
 			"entitlements": "assets/entitlements.mac.plist",
@@ -169,7 +171,10 @@
 		},
 		"win": {
 			"target": [
-				"nsis"
+				{
+					"target": "nsis",
+					"arch": ["x64", "arm64"]
+				}
 			]
 		},
 		"linux": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
 		"postinstall": "ts-node scripts/scripts/check-native-dep.js && electron-builder install-app-deps && cross-env NODE_ENV=development TS_NODE_TRANSPILE_ONLY=true webpack --config ./scripts/configs/webpack.config.renderer.dev.dll.ts",
 		"lint": "cross-env NODE_ENV=development eslint . --ext .js,.jsx,.ts,.tsx",
 		"package": "ts-node ./scripts/scripts/clean.js dist && npm run build && electron-builder build --publish never",
+		"package-mac": "ts-node ./scripts/scripts/clean.js dist && npm run build && electron-builder build --mac --publish never",
+		"package-lin": "ts-node ./scripts/scripts/clean.js dist && npm run build && electron-builder build --linux --publish never",
+		"package-win": "ts-node ./scripts/scripts/clean.js dist && npm run build && electron-builder build --win --x64  --publish never",
 		"rebuild": "electron-rebuild --parallel --types prod,dev,optional --module-dir release/app",
 		"start": "ts-node ./scripts/scripts/check-port-in-use.js && npm run start:renderer",
 		"start:main": "cross-env NODE_ENV=development electronmon -r ts-node/register/transpile-only .",
@@ -171,7 +174,10 @@
 		},
 		"linux": {
 			"target": [
-				"AppImage"
+				{
+					"target": "AppImage",
+					"arch": ["x64", "arm64"]
+				}
 			],
 			"category": "Development"
 		},

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -195,7 +195,7 @@ const createWindow = async () => {
 	const nativeImage = require('electron').nativeImage;
 	const dockIcon = nativeImage.createFromPath(getAssetPath('icon.png'));
 
-	app.dock.setIcon(dockIcon); // todo: if electronStore preferences say to hide icon, hide icon with app.dock.setMenu(Menu.buildFromTemplate([])); maybe https://stackoverflow.com/questions/59668664/how-to-avoid-showing-a-dock-icon-while-my-electron-app-is-launching-on-macos
+	app.dock?.setIcon(dockIcon); // todo: if electronStore preferences say to hide icon, hide icon with app.dock.setMenu(Menu.buildFromTemplate([])); maybe https://stackoverflow.com/questions/59668664/how-to-avoid-showing-a-dock-icon-while-my-electron-app-is-launching-on-macos
 	app.name = 'God Mode';
 
 	mainWindow.loadURL(resolveHtmlPath('index.html'));

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -175,6 +175,10 @@ const createWindow = async () => {
 
 	let { width, height } = screen.getPrimaryDisplay().workAreaSize;
 
+	const preload = app.isPackaged
+		? path.join(__dirname, 'preload.js')
+		: path.join(__dirname, '../../scripts/dll/preload.js');
+
 	mainWindow = new BrowserWindow({
 		show: false,
 		// frame: false,
@@ -186,9 +190,7 @@ const createWindow = async () => {
 		webPreferences: {
 			webviewTag: true,
 			nodeIntegration: true,
-			preload: app.isPackaged
-				? path.join(__dirname, 'preload.js')
-				: path.join(__dirname, '../../scripts/dll/preload.js'),
+			preload,
 		},
 	});
 


### PR DESCRIPTION
Running through the app to improve support for linux and windows. Initial change to have the app show up: app.dock isn't available outside of macos, so add a guard.

- add guard for app.dock so launching works
- extract preload so the built version on linux works
- configure package.json to create arch-specific builds for linux (appImage runs on many different platforms, solves #47 though usually Arch users build from source, which they now can with the package-lin command) and Windows (solves #157), as well as universal builds for mac (solves #163) and windows 
