### PR TITLE
Global Shortcut Hotfixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "godmode",
-	"version": "1.0.0-beta.1",
+	"version": "1.0.0-beta.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "godmode",
-			"version": "1.0.0-beta.1",
+			"version": "1.0.0-beta.2",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -155,8 +155,12 @@ const createWindow = async () => {
 	});
 
 	mainWindow.on('close', (event: Event) => {
-		event?.preventDefault();
-		mainWindow?.hide();
+		event.preventDefault();
+		mainWindow?.destroy();
+	});
+
+	app.on('activate', () => {
+		if (mainWindow === null) createWindow();
 	});
 
 	const menuBuilder = new MenuBuilder(mainWindow);

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -343,15 +343,19 @@ function changeGlobalShortcut(newShortcut: string) {
  */
 function quickOpen() {
 	if (mainWindow && !mainWindow.isDestroyed()) {
-		if (mainWindow.isMinimized()) {
-			mainWindow.restore();
+		if (mainWindow.isFocused()) {
+			mainWindow.hide();
+		} else {
+			if (mainWindow.isMinimized()) {
+				mainWindow.restore();
+			}
+			mainWindow.show();
+			mainWindow.focus();
+			// put focus on the #prompt textarea if it is at all present on the document inside mainWindow
+			mainWindow.webContents.executeJavaScript(
+				`{document.querySelector('#prompt')?.focus()}`,
+			);
 		}
-		mainWindow.show();
-		mainWindow.focus();
-		// put focus on the #prompt textarea if it is at all present on the document inside mainWindow
-		mainWindow.webContents.executeJavaScript(
-			`{document.querySelector('#prompt')?.focus()}`,
-		);
 	} else {
 		createWindow();
 	}

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -352,6 +352,8 @@ function quickOpen() {
 		mainWindow.webContents.executeJavaScript(
 			`{document.querySelector('#prompt')?.focus()}`,
 		);
+	} else {
+		createWindow();
 	}
 }
 


### PR DESCRIPTION
- Fixed issue preventing users from quitting the app.
-  Implemented functionality to resummon closed windows with a global shortcut.
-  Modified global shortcut to serve as a toggle, hiding the window if it is currently open and in focus. - resolves #131 and partially covers the functionality requested in #134  (i.e. makes the global shortcut a toggle, but does not remove the app from the app switcher)