### PR TITLE
fix: window switch on all keyboard layouts

### DIFF
--- a/src/renderer/layout.tsx
+++ b/src/renderer/layout.tsx
@@ -133,11 +133,17 @@ export default function Layout() {
 		const isCmdOrCtrl = event.metaKey || event.ctrlKey;
 		const isShift = event.shiftKey;
 		console.debug('keydown', event.key, isCmdOrCtrl, event);
-		if (isCmdOrCtrl && !isShift && event.key in paneShortcutKeys) {
-			if (paneShortcutKeys[event.key] === null) {
+		if (
+			isCmdOrCtrl &&
+			(event.key in paneShortcutKeys ||
+				(event.code.match(/Digit[1-9]/) &&
+					event.code[event.code.length - 1] in paneShortcutKeys))
+		) {
+			const digit = +event.key || +event.code[event.code.length - 1];
+			if (paneShortcutKeys[digit] === null) {
 				window.electron.browserWindow.reload(); // this is a hack; setSizes by itself does not seem to update the splits, seems like a bug, but we dont have a choice here
 			} else {
-				setOpenPreviewPane(+event.key);
+				setOpenPreviewPane(digit);
 			}
 		} else if (isCmdOrCtrl && isShift && event.key.toLowerCase() === 'a') {
 			window.electron.browserWindow.reload();


### PR DESCRIPTION
Add window switch shortcut using digit keys for all keyboard layouts. You can now switch between windows using the ⌘ (Command) or CTRL key in combination with the digit keys, regardless of your keyboard layout.

<img src="https://github.com/smol-ai/GodMode/assets/31932525/a933cc00-5b9b-4352-8100-0f6e1363da8f" alt="Switching Windows with Digit Keys" width="600">

**Fixes:** #158