### PR TITLE
fix: use a different user agent to ensure perplexity loads on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,9 +145,6 @@ If you want to build from source, you will need to clone the repo and open the p
    git clone https://github.com/smol-ai/GodMode.git
    cd GodMode
    npm install --force
-   # On Windows, you may also need Squirrel - these are old instructions, we would love a Windows volunteer to verify
-   # npm install electron-squirrel-startup
-
    npm run start # to run in development, locally
    ```
 

--- a/src/providers/perplexity-llama.js
+++ b/src/providers/perplexity-llama.js
@@ -92,6 +92,10 @@ class PerplexityLlama extends Provider {
 		});
 	}
 
+	static getUserAgent() {
+		'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36';
+	}
+
 	static isEnabled() {
 		return window.electron.electronStore.get(`${this.webviewId}Enabled`, false);
 	}

--- a/src/providers/perplexity.js
+++ b/src/providers/perplexity.js
@@ -58,6 +58,10 @@ class Perplexity extends Provider {
 		// this.getWebview().setZoomLevel(this.getWebview().getZoomLevel() - 2);
 	}
 
+	static getUserAgent() {
+		'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36';
+	}
+
 	static isEnabled() {
 		return window.electron.electronStore.get(`${this.webviewId}Enabled`, true);
 	}


### PR DESCRIPTION
Fixes #203.

User agent was copied from the claude2 provider.

I also updated the readme to remove the electron squirrel instructions, as I've never installed electron or the squirrel package, and had no issues setting up and running this repo on windows 11.