### PR TITLE
feat: add superprompt focus on quickopen shortcut

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "godmode",
-	"version": "1.0.0-beta.6",
+	"version": "1.0.0-beta.8",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "godmode",
-			"version": "1.0.0-beta.6",
+			"version": "1.0.0-beta.8",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -27,6 +27,8 @@ export interface ProviderInterface {
 export interface Settings {
 	getGlobalShortcut: () => Promise<string>;
 	setGlobalShortcut: (shortcut: string) => Promise<boolean>;
+	getFocusSuperprompt: () => Promise<boolean>;
+	setFocusSuperprompt: (state: boolean) => Promise<boolean>;
 	getPlatform: () => Promise<string>;
 }
 

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -65,6 +65,12 @@ contextBridge.exposeInMainWorld('settings', {
 	setGlobalShortcut: (shortcut: string) => {
 		return ipcRenderer.invoke('set-global-shortcut', shortcut);
 	},
+	getFocusSuperprompt: () => {
+		return ipcRenderer.invoke('get-focus-superprompt');
+	},
+	setFocusSuperprompt: (state: boolean) => {
+		return ipcRenderer.invoke('set-focus-superprompt', state);
+	},
 	getPlatform: () => {
 		return ipcRenderer.invoke('get-platform');
 	},


### PR DESCRIPTION
Adds a toggle switch to the settings menu for toggling superprompt input focus on quickopen shortcut. 
The default would be `false`, like the behavior is currently. 

Implementation of #251