### PR TITLE
fix: poe submit button selector

### DIFF
--- a/src/providers/poe.js
+++ b/src/providers/poe.js
@@ -8,7 +8,6 @@ class Poe extends Provider {
 	static url = 'https://poe.com/';
 
 	static handleInput(input) {
-		const fullName = this.fullName;
 		this.getWebview().executeJavaScript(`{
         var inputElement = document.querySelector('textarea');
         if (inputElement) {
@@ -23,9 +22,8 @@ class Poe extends Provider {
 
 	static handleSubmit() {
 		this.getWebview().executeJavaScript(`{
-        var buttons = Array.from(document.querySelectorAll('button.Button_primary__pIDjn'));
-				if (buttons[0]) {
-					var button = buttons[buttons.length - 1];
+        var button = document.querySelectorAll('button[class*="ChatMessageSendButton_sendButton"]')[0]
+				if (button) {
 					button.click();
 				}
     }`);


### PR DESCRIPTION
**Issue:**
The `handleSubmit` function in the poe provider had an issue with the button selector, causing it to fail when submitting. This happens because the class names include a generated string at the end of them.

**Solution:**
Fixed the button selector by checking for a substring of a class excluding the generated string.
